### PR TITLE
Make reproducible with Devenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+export DIRENV_WARN_TIMEOUT=20s
+
+eval "$(devenv direnvrc)"
+
+# `use devenv` supports the same options as the `devenv shell` command.
+#
+# To silence all output, use `--quiet`.
+#
+# Example usage: use devenv --quiet --impure --option services.postgres.enable:bool true
+use devenv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
 build/*
 *.pyc
+
+# Devenv
+.devenv*
+devenv.local.nix
+devenv.local.yaml
+
+# direnv
+.direnv
+
+# pre-commit
+.pre-commit-config.yaml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
   * `git clone https://github.com/freifunk/viewer.api.freifunk.net`
-  * `pip3 install -r requirements.txt`
+  * `direnv allow`
   * `python3 render.py [build_dir]`
   * `firefox build/index.html`
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,159 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1770807703,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "3d31cb4f4254810acc9038fec0bcdb6ec247cc5d",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770726378,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762808025,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1770434727,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "8430f16a39c27bdeef236f1eeb56f0b51b33d348",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770193939,
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "0630618bfe33895453257fb606af75aa71247393",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769922788,
+        "narHash": "sha256-H3AfG4ObMDTkTJYkd8cz1/RbY9LatN5Mk4UF48VuSXc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "207d15f1a6603226e1e223dc79ac29c7846da32e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  languages.python = {
+    enable = true;
+    version = "3.13.12";
+  };
+
+  packages = with pkgs; [
+    python313Packages.jinja2
+    python313Packages.requests
+    python313Packages.packaging
+    python313Packages.jsonschema
+    python313Packages.progressbar33
+    python313Packages.python-dateutil
+  ];
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,8 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python
+    inputs:
+      nixpkgs:
+        follows: nixpkgs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-Jinja2==3.1.6
-requests==2.32.5
-packaging==26.0
-jsonschema==4.26.0
-progressbar33==2.4
-python_dateutil==2.9.0.post0


### PR DESCRIPTION
I understand this is opinionated, feel free to reject this PR.

I propose that, for future development, we switch away from requirements.txt since it is an outdated standard for dependencies.

The reason I chose Devenv/Nix is because:
A) It ensures that everyone is using the correct Python version
B) All dependencies can be defined from Nixpkgs
C) Direnv auto-enables the Devenv environment when the developer enters the directory
D) Devenv doesn't just make Python reproducible, but also contains tools for declaratively installing toolchains for other languages. This means that npm, uv, and whatever else could be used in this repo going forward, don't need to be manually set up by every developer. Setup is automatic.

Of course, most of the same things can be achieved with uv or poetry as well.